### PR TITLE
Added support for most useful and widely supported HTML5 Input types

### DIFF
--- a/src/livevalidation_prototype.js
+++ b/src/livevalidation_prototype.js
@@ -237,7 +237,9 @@ LiveValidation.prototype = {
         return LiveValidation.TEXTAREA;
       case (nn == 'INPUT' && nt == 'TEXT'):
         return LiveValidation.TEXT;
-      case (nn == 'INPUT' && nt == 'PASSWORD'):
+	  case (nn == 'INPUT' && (nt == 'EMAIL' || nt == 'URL' || nt == 'TEL' || nt == 'NUMBER' || nt == 'RANGE')):
+	    return LiveValidation.TEXT;
+	  case (nn == 'INPUT' && nt == 'PASSWORD'):
         return LiveValidation.PASSWORD;
       case (nn == 'INPUT' && nt == 'CHECKBOX'):
         return LiveValidation.CHECKBOX;

--- a/src/livevalidation_standalone.js
+++ b/src/livevalidation_standalone.js
@@ -240,6 +240,8 @@ LiveValidation.prototype = {
 	        return LiveValidation.TEXTAREA;
 	      case (nn == 'INPUT' && nt == 'TEXT'):
 	        return LiveValidation.TEXT;
+	      case (nn == 'INPUT' && (nt == 'EMAIL' || nt == 'URL' || nt == 'TEL' || nt == 'NUMBER' || nt == 'RANGE')):
+	        return LiveValidation.TEXT;
 	      case (nn == 'INPUT' && nt == 'PASSWORD'):
 	        return LiveValidation.PASSWORD;
 	      case (nn == 'INPUT' && nt == 'CHECKBOX'):


### PR DESCRIPTION
New HTML5 Input types are being used now - this allows them to be used
by telling the script to treat them as Text (this is what browsers that
don't support the new types do anyway).
Could later be integrated more fully with default validation types
based on them.

Included: Email, URL, Tel, Number, Range.